### PR TITLE
Add a new plugin fetchinvoice inside the archive bash script

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -8,6 +8,6 @@ outputtar=${TARGET_HOST/v7a/}_lightning_ndk.tar
 tar -cf ${outputtar} -C bitcoin/depends/${TARGET_HOST/v7a/}/bin bitcoind bitcoin-cli
 tar -cf ${outputtar} ${BUILDROOT}/bin/tor
 tar -rf ${outputtar} -C lightning lightningd/lightning_channeld lightningd/lightning_closingd lightningd/lightning_connectd lightningd/lightning_gossipd lightningd/lightning_hsmd lightningd/lightning_onchaind lightningd/lightning_openingd lightningd/lightningd
-tar -rf ${outputtar} -C lightning plugins/autoclean plugins/keysend plugins/bcli plugins/esplora plugins/txprepare plugins/pay plugins/spenderp plugins/fetchinvoice
+tar -rf ${outputtar} -C lightning plugins/autoclean plugins/keysend plugins/bcli plugins/esplora plugins/txprepare plugins/pay plugins/spenderp plugins/fetchinvoice plugins/offers
 tar -rf ${outputtar} -C lightning cli/lightning-cli
 xz ${outputtar}

--- a/archive.sh
+++ b/archive.sh
@@ -8,6 +8,6 @@ outputtar=${TARGET_HOST/v7a/}_lightning_ndk.tar
 tar -cf ${outputtar} -C bitcoin/depends/${TARGET_HOST/v7a/}/bin bitcoind bitcoin-cli
 tar -cf ${outputtar} ${BUILDROOT}/bin/tor
 tar -rf ${outputtar} -C lightning lightningd/lightning_channeld lightningd/lightning_closingd lightningd/lightning_connectd lightningd/lightning_gossipd lightningd/lightning_hsmd lightningd/lightning_onchaind lightningd/lightning_openingd lightningd/lightningd
-tar -rf ${outputtar} -C lightning plugins/autoclean plugins/keysend plugins/bcli plugins/esplora plugins/txprepare plugins/pay plugins/spenderp
+tar -rf ${outputtar} -C lightning plugins/autoclean plugins/keysend plugins/bcli plugins/esplora plugins/txprepare plugins/pay plugins/spenderp plugins/fetchinvoice
 tar -rf ${outputtar} -C lightning cli/lightning-cli
 xz ${outputtar}


### PR DESCRIPTION
Here we go, I arrived also in this repository with a PR :-)

During the test of new tag with lamp I received a following error

`/data/user/0/com.lvaccaro.lamp/no_backup/lightningd/../plugins/fetchinvoice': opening pipe: No such file or directory`

And this PR add the plugin `fetchinvoice` inside the archive.sh bash script